### PR TITLE
Handle ordinal ranges such as 1.-9.

### DIFF
--- a/sling/nlp/document/text-tokenizer.cc
+++ b/sling/nlp/document/text-tokenizer.cc
@@ -954,15 +954,17 @@ void StandardTokenization::Process(TokenizerText *t) {
       int j = i + 1;
       while (j < t->length() && t->is(j, CHAR_DIGIT)) j++;
       if (t->at(j) == '.' &&
-          (t->at(j + 1) == 0 || t->is(j + 1, CHAR_SPACE | CHAR_PUNCT)) &&
+          (t->at(j + 1) == 0
+           || t->at(j + 1) == '-'
+           || t->is(j + 1, CHAR_SPACE | CHAR_PUNCT)) &&
           j - i < 3) {
-        // Mark oridinal token.
+        // Mark ordinal token.
         t->set(i, TOKEN_START);
         i = j + 1;
+        if (t->at(i) == '-') t->set(i, CHAR_HYPHEN);
         continue;
       }
     }
-
     // Check for other number tokens. Numbers start with a digit or a number
     // punctuation start character (like . , + -) followed by a digit.
     // The rest of the number token consists of digits, letters, and number


### PR DESCRIPTION
Handle ordinal ranges so "1.-9. klasse" gets handled as [1.]-[9.] rather than [1.][-9]. 
Also fixing minor comment typo. 